### PR TITLE
Restore scroll for BackButton on mobile

### DIFF
--- a/src/app/dice/page.tsx
+++ b/src/app/dice/page.tsx
@@ -10,7 +10,7 @@ import { lilita } from "@/lib/fonts";
 export default function Home() {
   return (
     <main className="overflow-x-hidden">
-      <BackButton className="absolute top-4 left-4 z-10" href="/" />
+      <BackButton className="absolute top-4 left-4 z-10" href="/#games" />
       <BeerContainer color="teal" className="h-screen w-screen">
         <h1 className={`${lilita.className} text-5xl text-center mt-12`}>
           Terningleken

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -24,7 +24,7 @@ export default function Home() {
         <ArrowDown className="animate-bounce" size={48} />
         <FoamWave className="mt-auto" />
       </div>
-      <div className="snap-start md:grow max-md:h-dvh">
+      <div className="snap-start md:grow max-md:h-dvh" id="games">
         <BeerContainer className="max-md:h-dvh">
           <h4 className={`${lilita.className} text-gray-800`}>Sanger</h4>
           <NavButton

--- a/src/app/questions/page.tsx
+++ b/src/app/questions/page.tsx
@@ -151,7 +151,7 @@ const QuestionsPage = () => {
 
   return (
     <main className="overflow-hidden h-screen">
-      <BackButton href="/" className="absolute top-4 left-4 z-10" />
+      <BackButton href="/#games" className="absolute top-4 left-4 z-10" />
       <BeerContainer color="fuchsia">
         <div className="flex flex-col items-center text-center h-full">
           <h1 className={`${lilita.className} text-5xl pt-12`}>100 Spørsmål</h1>

--- a/src/app/six-minutes/page.tsx
+++ b/src/app/six-minutes/page.tsx
@@ -116,7 +116,7 @@ const SixMinutes = () => {
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>
-      <BackButton href="/" className="absolute top-4 left-4 z-10" />
+      <BackButton href="/#games" className="absolute top-4 left-4 z-10" />
       <BeerContainer color="orange">
         <div className="text-center pt-12 flex flex-col h-full">
           <h1 className={`${lilita.className} text-5xl`}>6 Minutes</h1>

--- a/src/app/song/forever-alone/page.tsx
+++ b/src/app/song/forever-alone/page.tsx
@@ -117,7 +117,7 @@ const foreverAlone = [
 const ForeverAlonePage = () => {
   return (
     <main className="overflow-x-hidden">
-      <BackButton className="absolute top-4 left-4 z-10" href="/" />
+      <BackButton className="absolute top-4 left-4 z-10" href="/#games" />
       <BeerContainer color="green" className="min-h-dvh">
         <Lyrics title="Forever Alone" lyrics={foreverAlone} />
         <Footer />

--- a/src/app/song/lambo/page.tsx
+++ b/src/app/song/lambo/page.tsx
@@ -30,7 +30,7 @@ const lambo = [
 const LamboPage = () => {
   return (
     <main className="overflow-x-hidden">
-      <BackButton className="absolute top-4 left-4 z-10" href="/" />
+      <BackButton className="absolute top-4 left-4 z-10" href="/#games" />
       <BeerContainer color="red" className="min-h-dvh">
         <Lyrics title="Lambo" lyrics={lambo} />
         <Footer />

--- a/src/app/song/lay-all-your-love-on-me/page.tsx
+++ b/src/app/song/lay-all-your-love-on-me/page.tsx
@@ -55,7 +55,7 @@ const layAllYourLoveOnMe = [
 const LayAllYourLoveOnMePage = () => {
   return (
     <main className="overflow-x-hidden">
-      <BackButton className="absolute top-4 left-4 z-10" href="/" />
+      <BackButton className="absolute top-4 left-4 z-10" href="/#games" />
       <BeerContainer color="blue" className="min-h-dvh">
         <Lyrics title="Lay All Your Love On Me" lyrics={layAllYourLoveOnMe} />
         <Footer />


### PR DESCRIPTION
When you pressed the Back button previously, you were directed to the splash screen instead of the game selection. Now it automatically get redirected to the game section, so that you don't have to scroll down.

https://github.com/user-attachments/assets/da140536-b470-4c06-93f1-3db19659cfbf

