### PR TITLE
Restore question number from localStorage

### DIFF
--- a/src/app/questions/page.tsx
+++ b/src/app/questions/page.tsx
@@ -127,21 +127,21 @@ interface StoredQuestion {
 }
 
 const getStoredQuestion = (): number | undefined => {
-  if (typeof window === "undefined") return
-  
+  if (typeof window === "undefined") return;
+
   try {
     const storedData = localStorage.getItem("current_question");
     if (!storedData) return;
-    
+
     const { question, updatedAt }: StoredQuestion = JSON.parse(storedData);
-    
+
     const storedTime = new Date(updatedAt).getTime();
     const now = new Date().getTime();
-    const isRecent = now - storedTime < 30_000
-    
-    if (isRecent) return question
+    const isRecent = now - storedTime < 30_000;
+
+    if (isRecent) return question;
   } catch {}
-}
+};
 
 const QuestionsPage = () => {
   const [currentCard, setCurrentCard] = useState(getStoredQuestion() || 0);
@@ -169,11 +169,13 @@ const QuestionsPage = () => {
         currentCard + 5,
       ),
     );
-    localStorage.setItem("current_question", JSON.stringify({ 
-        question: currentCard, 
-        updatedAt: new Date() 
-      })
-    )
+    localStorage.setItem(
+      "current_question",
+      JSON.stringify({
+        question: currentCard,
+        updatedAt: new Date(),
+      }),
+    );
   }, [currentCard]);
 
   return (

--- a/src/app/questions/page.tsx
+++ b/src/app/questions/page.tsx
@@ -121,8 +121,30 @@ interface Card {
   };
 }
 
+interface StoredQuestion {
+  question: number;
+  updatedAt: string;
+}
+
+const getStoredQuestion = (): number | undefined => {
+  if (typeof window === "undefined") return
+  
+  try {
+    const storedData = localStorage.getItem("current_question");
+    if (!storedData) return;
+    
+    const { question, updatedAt }: StoredQuestion = JSON.parse(storedData);
+    
+    const storedTime = new Date(updatedAt).getTime();
+    const now = new Date().getTime();
+    const isRecent = now - storedTime < 30_000
+    
+    if (isRecent) return question
+  } catch {}
+}
+
 const QuestionsPage = () => {
-  const [currentCard, setCurrentCard] = useState(0);
+  const [currentCard, setCurrentCard] = useState(getStoredQuestion() || 0);
   const [cards, setCards] = useState<Card[]>([]);
 
   useEffect(() => {
@@ -147,6 +169,11 @@ const QuestionsPage = () => {
         currentCard + 5,
       ),
     );
+    localStorage.setItem("current_question", JSON.stringify({ 
+        question: currentCard, 
+        updatedAt: new Date() 
+      })
+    )
   }, [currentCard]);
 
   return (


### PR DESCRIPTION
I think 30 seconds might be a bit short as this compares to when you last updated changed the question, which can be some time. Maybe 5 / 10 min are good, could also add a "go to beginning" button if they wanted to start anew (i think that is a rare case)

Anyways noticed that we probably should have a "previous question" button anyways

Resolves ABA-998